### PR TITLE
Add Graph6Converter with tests

### DIFF
--- a/graph_converter.py
+++ b/graph_converter.py
@@ -1,0 +1,61 @@
+import itertools
+import networkx as nx
+from networkx.readwrite.graph6 import _generate_graph6_bytes
+
+
+class Graph6Converter:
+    """Convert between custom edge-list format and canonical graph6."""
+
+    @staticmethod
+    def _parse_edge_list(text: str) -> nx.Graph:
+        """Parse edge-list formatted as 'n: u,v ; x,y ...'."""
+        text = text.strip()
+        if not text:
+            raise ValueError("Empty graph description")
+        parts = text.split(":", 1)
+        if len(parts) != 2:
+            raise ValueError("Missing ':' separator")
+        n = int(parts[0].strip())
+        G = nx.Graph()
+        G.add_nodes_from(range(n))
+        edges_part = parts[1]
+        if edges_part.strip() == "":
+            return G
+        # remove spaces around semicolons and commas
+        edges = [e.strip() for e in edges_part.split(";") if e.strip()]
+        for e in edges:
+            u_str, v_str = [x.strip() for x in e.split(",")]
+            u = int(u_str) - 1
+            v = int(v_str) - 1
+            if u < 0 or v < 0 or u >= n or v >= n:
+                raise ValueError("Vertex index out of range")
+            if u != v:
+                G.add_edge(u, v)
+        return G
+
+    @staticmethod
+    def _graph_to_edge_list(G: nx.Graph) -> str:
+        n = len(G)
+        edges = sorted({tuple(sorted((u + 1, v + 1))) for u, v in G.edges()})
+        edges_str = " ; ".join(f"{u},{v}" for u, v in edges)
+        return f"{n}: {edges_str}" if edges_str else f"{n}:"
+
+    @staticmethod
+    def _canonical_graph6(G: nx.Graph) -> str:
+        nodes = list(G.nodes())
+        best = None
+        for perm in itertools.permutations(nodes):
+            mapping = {perm[i]: i for i in range(len(perm))}
+            H = nx.relabel_nodes(G, mapping)
+            g6 = b"".join(_generate_graph6_bytes(H, range(len(perm)), False)).decode().strip()
+            if best is None or g6 < best:
+                best = g6
+        return best
+
+    def edge_list_to_graph6(self, text: str) -> str:
+        G = self._parse_edge_list(text)
+        return self._canonical_graph6(G)
+
+    def graph6_to_edge_list(self, g6: str) -> str:
+        G = nx.from_graph6_bytes(g6.strip().encode())
+        return self._graph_to_edge_list(G)

--- a/tests/test_graph_converter.py
+++ b/tests/test_graph_converter.py
@@ -1,0 +1,37 @@
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import glob
+import unittest
+import networkx as nx
+from graph_converter import Graph6Converter
+
+
+class TestGraph6Converter(unittest.TestCase):
+    def setUp(self):
+        self.conv = Graph6Converter()
+
+    def test_roundtrip_example(self):
+        text = "5: 1,2 ; 1,3 ; 1,4 ; 2,5 ; 3,5 ; 4,5"
+        g6 = self.conv.edge_list_to_graph6(text)
+        back = self.conv.graph6_to_edge_list(g6)
+        self.assertEqual(g6, self.conv.edge_list_to_graph6(back))
+
+    def test_data_graphs_roundtrip(self):
+        data_files = glob.glob(os.path.join('data', '*.g6.txt'))
+        for fname in data_files:
+            with open(fname) as f:
+                for i, line in enumerate(f):
+                    if i >= 5:
+                        break
+                    g6 = line.strip()
+                    if not g6:
+                        continue
+                    edges = self.conv.graph6_to_edge_list(g6)
+                    g6_again = self.conv.edge_list_to_graph6(edges)
+                    G1 = nx.from_graph6_bytes(g6.encode())
+                    G2 = nx.from_graph6_bytes(g6_again.encode())
+                    self.assertTrue(nx.is_isomorphic(G1, G2))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_udg.py
+++ b/tests/test_udg.py
@@ -1,3 +1,4 @@
+import sys, os; sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import unittest
 from udg import Graph, udg_recognition
 


### PR DESCRIPTION
## Summary
- implement `Graph6Converter` for converting edge lists to canonical `graph6`
- add unit tests for conversion
- adjust existing tests to import project modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c65cf91808332b6639c06d70697d6