### PR TITLE
Add CLI to Graph6Converter

### DIFF
--- a/Graph6Converter.py
+++ b/Graph6Converter.py
@@ -1,6 +1,7 @@
 import itertools
+import argparse
 import networkx as nx
-from networkx.readwrite.graph6 import _generate_graph6_bytes
+from networkx.readwrite.graph6 import _generate_graph6_bytes, to_graph6_bytes
 
 
 class Graph6Converter:
@@ -52,10 +53,64 @@ class Graph6Converter:
                 best = g6
         return best
 
-    def edge_list_to_graph6(self, text: str) -> str:
+    def edge_list_to_graph6(self, text: str, canonical: bool = True) -> str:
+        """Convert edge-list text to graph6 string."""
         G = self._parse_edge_list(text)
-        return self._canonical_graph6(G)
+        if canonical:
+            return self._canonical_graph6(G)
+        return to_graph6_bytes(G, nodes=sorted(G.nodes()), header=False).decode().strip()
 
     def graph6_to_edge_list(self, g6: str) -> str:
         G = nx.from_graph6_bytes(g6.strip().encode())
         return self._graph_to_edge_list(G)
+
+    def canonicalize_graph6(self, g6: str) -> str:
+        """Return canonical graph6 representation for given graph6 string."""
+        G = nx.from_graph6_bytes(g6.strip().encode())
+        return self._canonical_graph6(G)
+
+    def canonicalize_edge_list(self, text: str) -> str:
+        """Return canonical edge-list representation for given edge-list text."""
+        g6 = self.edge_list_to_graph6(text, canonical=True)
+        return self.graph6_to_edge_list(g6)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Convert between edge-list and graph6 representations")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "-g", "--to_graph6", action="store_true",
+        help="Interpret input as edge list and output graph6")
+    group.add_argument(
+        "-e", "--to_edge_list", action="store_true",
+        help="Interpret input as graph6 and output edge list")
+    parser.add_argument(
+        "-c", "--make_canonical", action="store_true",
+        help="Canonicalize the graph before output")
+    parser.add_argument(
+        "graph", metavar="GRAPH",
+        help="Input graph description")
+
+    args = parser.parse_args()
+
+    conv = Graph6Converter()
+
+    if args.to_graph6:
+        if args.make_canonical:
+            output = conv.edge_list_to_graph6(args.graph, canonical=True)
+        else:
+            output = conv.edge_list_to_graph6(args.graph, canonical=False)
+    else:  # to_edge_list
+        if args.make_canonical:
+            canon = conv.canonicalize_graph6(args.graph)
+            output = conv.graph6_to_edge_list(canon)
+        else:
+            output = conv.graph6_to_edge_list(args.graph)
+
+    print(output)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_graph_converter.py
+++ b/tests/test_graph_converter.py
@@ -5,6 +5,7 @@ import glob
 import unittest
 import networkx as nx
 from Graph6Converter import Graph6Converter
+import subprocess
 
 
 class TestGraph6Converter(unittest.TestCase):
@@ -32,6 +33,20 @@ class TestGraph6Converter(unittest.TestCase):
                     G1 = nx.from_graph6_bytes(g6.encode())
                     G2 = nx.from_graph6_bytes(g6_again.encode())
                     self.assertTrue(nx.is_isomorphic(G1, G2))
+
+    def test_cli_to_graph6(self):
+        text = "3: 1,2 ; 2,3"
+        expected = self.conv.edge_list_to_graph6(text, canonical=False)
+        script = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'Graph6Converter.py')
+        res = subprocess.run([sys.executable, script, '-g', text], capture_output=True, text=True)
+        self.assertEqual(res.stdout.strip(), expected)
+
+    def test_cli_to_edge_list_canonical(self):
+        g6 = self.conv.edge_list_to_graph6("4: 1,2 ; 2,3 ; 3,4")
+        script = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'Graph6Converter.py')
+        res = subprocess.run([sys.executable, script, '-e', '-c', g6], capture_output=True, text=True)
+        expected = self.conv.graph6_to_edge_list(self.conv.canonicalize_graph6(g6))
+        self.assertEqual(res.stdout.strip(), expected)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- support canonical/non-canonical outputs in Graph6Converter
- expose new `canonicalize_*` helper methods
- implement command line interface using `argparse`
- test command line conversions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685da52496b48332bbed6e7d5965517d