### PR TITLE
Add verbose option to udg_recognition

### DIFF
--- a/udg.py
+++ b/udg.py
@@ -157,10 +157,11 @@ def has_discrete_realization(graph: Graph, eps: float):
     return result
 
 
-def udg_recognition(graph: Graph, initial_epsilon=0.7):
+def udg_recognition(graph: Graph, initial_epsilon=0.7, eps_min=1e-3, verbose=False):
     eps = initial_epsilon
-    eps_min = 1e-3
     while True:
+        if verbose:
+            print(f"Checking epsilon: {eps}")
         result = has_discrete_realization(graph, eps)
         if result == YES:
             return True


### PR DESCRIPTION
## Summary
- add an optional `verbose` flag to `udg_recognition`
- allow custom minimal epsilon for experimentation

## Testing
- `pytest -q` *(fails due to long runtime; interrupted after completion)*

------
https://chatgpt.com/codex/tasks/task_e_68603b53e02c833299a3df0b63f6e44a