### PR TITLE
Add graphical viewer for discrete disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # UDG
 Unit Disc Graph
+
+## Discrete Disk utilities
+
+`discrete_disk.py` can generate a matrix describing a discrete disk and
+now includes a `display` function to visualise this matrix using
+`matplotlib`.  Running the module directly prints an ASCII view and pops
+up a graphical preview of the generated disk.

--- a/discrete_disk.py
+++ b/discrete_disk.py
@@ -99,6 +99,34 @@ def show(M: np.ndarray, symbol_map : np.ndarray = np.array(['◦', '▒', '?', '
     rows = [''.join(symbol_map[row]) for row in M[::-1]]
     return '\n'.join(rows)
 
+def display(M: np.ndarray, ax=None) -> "plt.Axes":
+    """Display the disk using :mod:`matplotlib`.
+
+    Parameters
+    ----------
+    M : np.ndarray
+        Matrix returned by :func:`discrete_disk`.
+    ax : matplotlib.axes.Axes, optional
+        Target axes. If ``None``, a new figure and axes are created.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+        The axes with the rendered image.
+    """
+    import matplotlib.pyplot as plt
+    from matplotlib.colors import ListedColormap
+
+    if ax is None:
+        _, ax = plt.subplots()
+
+    cmap = ListedColormap(['white', 'lightgray', 'red', 'black'])
+    ax.imshow(M[::-1], interpolation='nearest', cmap=cmap, vmin=0, vmax=3)
+    ax.set_xticks([])
+    ax.set_yticks([])
+    ax.set_aspect('equal', adjustable='box')
+    return ax
+
 if __name__ == "__main__":
     n = 16
     A = discrete_disk(n)  # A = dysk o promieniu n
@@ -119,6 +147,10 @@ if __name__ == "__main__":
     print(show(meet(A, A, (16, 0))))
     # print("B:\n", show(B))
     # print("C = A ⊓ B:\n", show(C))
+
+    display(A)
+    import matplotlib.pyplot as plt
+    plt.show()
 
 
 # if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- enhance `discrete_disk.py` with a `display` function using Matplotlib
- show the discrete disk graphically when the module is executed directly
- document the new feature in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fb8dd9bac833285fa57eec7ddb4ec